### PR TITLE
Fix Swagger GET request body issue for job endpoints

### DIFF
--- a/src/jobs/dto/job-order-by.dto.ts
+++ b/src/jobs/dto/job-order-by.dto.ts
@@ -1,5 +1,4 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { IsOptional, IsEnum } from 'class-validator';
+import {Field} from '@/common/decorators/field.decorator';
 
 /**
  * Sort order enum for job queries
@@ -23,48 +22,53 @@ export enum SortOrder {
  * - company: Company name (alphabetical)
  */
 export class JobOrderByDto {
-  @ApiProperty({
+  @Field({
+    name: 'createdAt',
     description: 'Sort by creation date',
     enum: SortOrder,
-    required: false,
+    optional: true,
+    inQuery: true,
+    isEnum: {entity: SortOrder},
   })
-  @IsOptional()
-  @IsEnum(SortOrder)
   createdAt?: SortOrder;
 
-  @ApiProperty({
+  @Field({
+    name: 'updatedAt',
     description: 'Sort by last update date',
     enum: SortOrder,
-    required: false,
+    optional: true,
+    inQuery: true,
+    isEnum: {entity: SortOrder},
   })
-  @IsOptional()
-  @IsEnum(SortOrder)
   updatedAt?: SortOrder;
 
-  @ApiProperty({
+  @Field({
+    name: 'postedAt',
     description: 'Sort by original posting date',
     enum: SortOrder,
-    required: false,
+    optional: true,
+    inQuery: true,
+    isEnum: {entity: SortOrder},
   })
-  @IsOptional()
-  @IsEnum(SortOrder)
   postedAt?: SortOrder;
 
-  @ApiProperty({
+  @Field({
+    name: 'title',
     description: 'Sort by job title',
     enum: SortOrder,
-    required: false,
+    optional: true,
+    inQuery: true,
+    isEnum: {entity: SortOrder},
   })
-  @IsOptional()
-  @IsEnum(SortOrder)
   title?: SortOrder;
 
-  @ApiProperty({
+  @Field({
+    name: 'company',
     description: 'Sort by company name',
     enum: SortOrder,
-    required: false,
+    optional: true,
+    inQuery: true,
+    isEnum: {entity: SortOrder},
   })
-  @IsOptional()
-  @IsEnum(SortOrder)
   company?: SortOrder;
 }

--- a/src/jobs/job.controller.ts
+++ b/src/jobs/job.controller.ts
@@ -51,7 +51,7 @@ export class JobController {
     description: 'Retrieves a paginated list of job listings with optional filtering',
     paginatedResponseType: JobDto,
     envelope: true,
-    queriesFrom: [PaginationArgs, JobFilterQueryDto],
+    queriesFrom: [PaginationArgs, JobFilterQueryDto, JobOrderByDto],
   })
   async findAll(
     @Query() paginationArgs: PaginationArgs,
@@ -86,7 +86,7 @@ export class JobController {
     pathParamsFrom: CompanyPathParamsDto,
     paginatedResponseType: JobDto,
     envelope: true,
-    queriesFrom: [PaginationArgs],
+    queriesFrom: [PaginationArgs, JobOrderByDto],
   })
   async findByCompany(
     @Param('companyId', ParseIntPipe) companyId: number,
@@ -107,7 +107,7 @@ export class JobController {
     pathParamsFrom: TagPathParamsDto,
     paginatedResponseType: JobDto,
     envelope: true,
-    queriesFrom: [PaginationArgs],
+    queriesFrom: [PaginationArgs, JobOrderByDto],
   })
   async findByTag(@Param('tagName') tagName: string, @Query() paginationArgs: PaginationArgs, @Query() orderBy: JobOrderByDto) {
     return this.jobService.findByTag(tagName, paginationArgs, orderBy);
@@ -123,8 +123,6 @@ export class JobController {
     responses: [{status: 200, description: 'Jobs fetched and notifications sent.'}],
   })
   async fetchJobs(): Promise<{redditJobs: any[]; web3CareerJobs: any[]; summary: any}> {
-    6;
-
     // Fetch Reddit jobs
     const redditSubreddits = ['remotejs', 'remotejobs', 'forhire', 'jobs', 'webdevjobs'];
     const redditPosts = await this.redditService.fetchRedditPosts(redditSubreddits);


### PR DESCRIPTION
## Summary
Fixes the 'GET Request cannot have a body' error when using the  endpoint in Swagger UI.

## Changes
1. **JobOrderByDto**: Converted from  to  decorator with  flag
   - This ensures sorting parameters are treated as query parameters, not body properties

2. **Api Decorator**: Enhanced body type inference logic
   - Now excludes DTOs specified in `queriesFrom` and `pathParamsFrom` from automatic body type inference
   - Prevents GET endpoints from incorrectly being assigned a request body

3. **Job Controller**: 
   - Added `JobOrderByDto` to `queriesFrom` arrays in all GET endpoints that use sorting
   - Removed stray code statement in `fetchJobs` method

## Testing
- [x] GET /jobs endpoint no longer shows request body in Swagger docs
- [x] Sorting parameters appear as query parameters
- [x] No TypeScript errors
- [x] Can successfully test endpoint in Swagger UI without body error

## Related Issue
Resolves issue where Swagger UI was generating invalid curl commands with request bodies for GET requests.